### PR TITLE
Fix issue with creation uploads sometimes failing

### DIFF
--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -9,6 +9,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NPTicket" Version="3.1.1" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />

--- a/GameServer/Program.cs
+++ b/GameServer/Program.cs
@@ -1,10 +1,11 @@
+using System.IO;
+using GameServer.Utils;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using GameServer.Utils;
-using Microsoft.EntityFrameworkCore;
 using Serilog.Events;
-using System.IO;
 
 namespace GameServer
 {
@@ -64,7 +65,13 @@ namespace GameServer
             }
 
             Database database = new();
+            var newDb = !database.Database.GetService<Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator>().Exists();
             database.Database.Migrate();
+            if (newDb)
+            {
+                database.Database.ExecuteSql($"ALTER TABLE PlayerCreations AUTO_INCREMENT = 10000;");   // Start id for PlayerCreations
+                database.SaveChanges();
+            }
             database.Dispose();
 
             CreateHostBuilder(args).Build().Run();

--- a/GameServer/Utils/Database.cs
+++ b/GameServer/Utils/Database.cs
@@ -45,11 +45,7 @@ namespace GameServer.Utils
         public DbSet<Moderator> Moderators { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder options) =>
-            options.UseMySql(ServerConfig.Instance.MysqlConnectionString, ServerVersion.AutoDetect(ServerConfig.Instance.MysqlConnectionString))
-            .UseSeeding((context, _) =>
-            {
-                context.Database.SqlQueryRaw<int>("ALTER TABLE PlayerCreations AUTO_INCREMENT = 10000;");
-            });
+            options.UseMySql(ServerConfig.Instance.MysqlConnectionString, ServerVersion.AutoDetect(ServerConfig.Instance.MysqlConnectionString));
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
This should fix the issue with duplicate tracked EF queries and also improve the performance of the creation create endpoint

This PR needs testing before merge

The code before was guessing an id based on the total creations in the database, this new PR makes autoincrement behave how we want it to then relies on that instead, creation id is fetched by commiting the player creation to the database, where EF will then update the tracked entities primary key with the key the database gave it, which we can then use in further queries.