### PR TITLE
console id ban by player session and remove profile avatars

### DIFF
--- a/GameServer/Controllers/Api/ModerationApiController.cs
+++ b/GameServer/Controllers/Api/ModerationApiController.cs
@@ -515,6 +515,23 @@ namespace GameServer.Controllers.Api
             else
                 return Content(result);
         }
+
+        [HttpDelete]
+        [Authorize(Policy = JWTUtils.ModeratorPolicy)]
+        [Route("/api/moderation/users/{id}/avatar")]
+        public IActionResult RemoveProfileAvatars(int id, bool isMNR = false)
+        {
+            var user = Moderation.GetUser(database, User);
+            if (user == null || !user.RemoveProfileAvatars)
+                return StatusCode(403);
+
+            var result = Moderation.RemoveProfileAvatars(database, storage, id, isMNR);
+
+            if (result == null)
+                return NotFound();
+            else
+                return Content(result);
+        }
         #endregion
 
         #region PlayerComplaints
@@ -1033,6 +1050,23 @@ namespace GameServer.Controllers.Api
                 return StatusCode(403);
 
             var result = Moderation.RemoveBannedConsoleId(consoleId);
+
+            if (result == null)
+                return NotFound();
+            else
+                return Content(result);
+        }
+
+        [HttpPost]
+        [Authorize(Policy = JWTUtils.ModeratorPolicy)]
+        [Route("/api/moderation/banned_console_ids/player/{userId}")]
+        public IActionResult AddConsoleIdByPlayerSession(int userId)
+        {
+            var user = Moderation.GetUser(database, User);
+            if (user == null || !user.ManageBannedConsoleIDs)
+                return StatusCode(403);
+
+            var result = Moderation.AddConsoleIdByPlayerSession(database, userId);
 
             if (result == null)
                 return NotFound();

--- a/GameServer/Controllers/Api/PlayerApiController.cs
+++ b/GameServer/Controllers/Api/PlayerApiController.cs
@@ -44,6 +44,9 @@ namespace GameServer.Controllers.Api
                     skillLevelIdPSV = x.PlayerExperiencePoints.Where(p => p.Platform == Platform.PSV)
                         .Sum(p => p.Amount) + x.PlayerCreationPoints.Where(p => p.Platform == Platform.PSV)
                         .Sum(p => p.Amount),
+                    skillLevelIdPSP = x.PlayerExperiencePoints.Where(p => p.Platform == Platform.PSP)
+                        .Sum(p => p.Amount) + x.PlayerCreationPoints.Where(p => p.Platform == Platform.PSP)
+                        .Sum(p => p.Amount),
                     skillRating = x.Points(Platform.PS3),
                     x.WinStreak,
                     x.LongestWinStreak,
@@ -86,6 +89,7 @@ namespace GameServer.Controllers.Api
 
             var skillLevelPS3 = SkillConfig.Instance.GetSkillLevel(player.skillLevelIdPS3);
             var skillLevelPSV = SkillConfig.Instance.GetSkillLevel(player.skillLevelIdPSV);
+            var skillLevelPSP = SkillConfig.Instance.GetSkillLevel(player.skillLevelIdPSP);
 
             return Json(new
             {
@@ -102,6 +106,7 @@ namespace GameServer.Controllers.Api
                 {
                     ["PS3"] = new { skillLevelPS3.Id, skillLevelPS3.Name },
                     ["PSV"] = new { skillLevelPSV.Id, skillLevelPSV.Name },
+                    ["PSP"] = new { skillLevelPSP.Id, skillLevelPSP.Name }
                 },
                 player.skillRating,
                 player.WinStreak,

--- a/GameServer/Implementation/Common/Moderation.cs
+++ b/GameServer/Implementation/Common/Moderation.cs
@@ -848,6 +848,19 @@ namespace GameServer.Implementation.Common
 
             return "ok";
         }
+
+        public static string RemoveProfileAvatars(Database database, IUGCStorage storage, int targetUserId, bool isMNR = false)
+        {
+            if (!database.Users.Any(u => u.UserId == targetUserId))
+                return null;
+
+            var user = database.Users.First(u => u.UserId == targetUserId);
+
+            if (ServerConfig.Instance.DeleteCreationData)
+                storage.RemoveProfileAvatars(targetUserId, isMNR);
+
+            return "ok";
+        }
         #endregion
 
         #region PlayerComplaints
@@ -1441,6 +1454,18 @@ namespace GameServer.Implementation.Common
 
             return "ok";
         }
+        public static string AddConsoleIdByPlayerSession(Database database, int userId)
+        {
+            var session = database.Sessions.FirstOrDefault(match => match.UserId == userId);
+
+            if (session == null)
+                return "no_active_session";
+
+            if (!Session.TryGetLastConnectionIdentity(userId, out var consoleId))
+                return "no_console_id_found";
+
+            return AddBannedConsoleId(consoleId);
+        }
         #endregion
 
         #region TeamPicksManagement
@@ -1525,6 +1550,7 @@ namespace GameServer.Implementation.Common
                 RemovePlayerCreations = permissions.RemovePlayerCreations,
                 RemovePlayerCreationComments = permissions.RemovePlayerCreationComments,
                 RemoveProfileComments = permissions.RemoveProfileComments,
+                RemoveProfileAvatars = permissions.RemoveProfileAvatars,
                 ResetCreationStats = permissions.ResetCreationStats,
                 ResetUserStats = permissions.ResetUserStats,
                 RemoveUsers = permissions.RemoveUsers
@@ -1563,7 +1589,8 @@ namespace GameServer.Implementation.Common
                 RemoveScores = true,
                 ManageUserSessions = true,
                 ManageBannedIPs = true,
-                ManageBannedConsoleIDs = true
+                ManageBannedConsoleIDs = true,
+                RemoveProfileAvatars = true
             });
         }
 

--- a/GameServer/Implementation/Common/Moderation.cs
+++ b/GameServer/Implementation/Common/Moderation.cs
@@ -314,6 +314,8 @@ namespace GameServer.Implementation.Common
 
             if (status == ModerationStatus.BANNED || status == ModerationStatus.ILLEGAL)
             {
+                ResetCreationStats(database, id);
+                
                 var hotlap = ContentUpdates.ReadHotlapData();
                 if (hotlap != null && hotlap.TrackId == id)
                     ContentUpdates.GetNewHotLap(database);

--- a/GameServer/Implementation/Common/Session.cs
+++ b/GameServer/Implementation/Common/Session.cs
@@ -16,11 +16,16 @@ using NPTicket.Verification.Keys;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Claims;
+using System.Collections.Concurrent;
 
 namespace GameServer.Implementation.Common
 {
     public class Session
     {
+        private record ConnectionIdentity(string ConsoleId);
+
+        private static readonly ConcurrentDictionary<int, ConnectionIdentity> LastConnectionByUserId = new();
+
         public static string Login(Database database, IPAddress ip, Platform platform, string ticket, string hmac, string console_id, bool policyAccepted, out string token)
         {
             token = null;
@@ -197,7 +202,7 @@ namespace GameServer.Implementation.Common
             };
 
             List<string> MNR_IDs = [ "BCUS98167", "BCES00701", "BCES00764", "BCJS30041", "BCAS20105", 
-                "BCKS10122", "NPEA00291", "NPUA80535", "BCET70020", "NPUA70074", "NPEA90062", "NPUA70096", "NPJA90132" ];
+                "BCKS10122", "NPEA00291", "NPUA80535", "BCET70020", "NPUA70074", "NPEA90062", "NPUA70096", "NPJA90132", "NPWR00300"];
 
             if (MNR_IDs.Contains(NPTicket.TitleId) || platform != Platform.PS3)
                 session.IsMNR = true;
@@ -220,6 +225,8 @@ namespace GameServer.Implementation.Common
                 };
                 return errorResp.Serialize();
             }
+
+            LastConnectionByUserId[user.UserId] = new ConnectionIdentity(console_id);
             
             database.Sessions.Add(session);
             database.SaveChanges();
@@ -344,6 +351,17 @@ namespace GameServer.Implementation.Common
         public static User GetUser(Database database, ClaimsPrincipal user)
         {
             return GetSession(database, user).User;
+        }
+
+        public static bool TryGetLastConnectionIdentity(int userId, out string consoleId)
+        {
+            consoleId = null;
+
+            if (!LastConnectionByUserId.TryGetValue(userId, out var identity))
+                return false;
+
+            consoleId = identity.ConsoleId;
+            return true;
         }
 
         public static void WriteWhitelist(List<string> whitelist)

--- a/GameServer/Implementation/Storage/LocalStorage.cs
+++ b/GameServer/Implementation/Storage/LocalStorage.cs
@@ -287,6 +287,16 @@ namespace GameServer.Implementation.Storage
             if (Directory.Exists(directory))
                 Directory.Delete(directory, true);
         }
+
+        public void RemoveProfileAvatars(int id, bool isMNR = false)
+        {
+            var dir = $"{Config.StoragePath}/PlayerAvatars/{id}/";
+            var mnrDir = $"{Config.StoragePath}/PlayerAvatars/{id}/MNR/";
+            if (Directory.Exists(dir) && !isMNR)
+                Directory.Delete(dir, true);
+            else if (Directory.Exists(mnrDir) && isMNR)
+                Directory.Delete(mnrDir, true);
+        }
         
         public void Dispose()
         {

--- a/GameServer/Implementation/Storage/S3Storage.cs
+++ b/GameServer/Implementation/Storage/S3Storage.cs
@@ -432,6 +432,41 @@ namespace GameServer.Implementation.Storage
             }
             catch (AmazonS3Exception) { }
         }
+
+        public void RemoveProfileAvatars(int id, bool isMNR = false)
+        {
+            List<string> keys;
+
+            if (isMNR)
+            {
+                keys = new List<string>()
+                {
+                    $"player_avatars/MNR/{id}/primary.png",
+                    $"player_avatars/MNR/{id}/primary_128x128.png",
+                    $"player_avatars/MNR/{id}/secondary.png",
+                    $"player_avatars/MNR/{id}/secondary_128x128.png",
+                };
+            }
+            else
+            {
+                keys = new List<string>()
+                {
+                    $"player_avatars/{id}/primary.png",
+                    $"player_avatars/{id}/primary_128x128.png",
+                    $"player_avatars/{id}/frowny.png",
+                    $"player_avatars/{id}/smiley.png"
+                };
+            }
+
+            foreach (var key in keys)
+            {
+                try
+                {
+                    S3Client.DeleteObjectAsync(Config.BucketName, key).Wait();
+                }
+                catch (AmazonS3Exception) { }
+            }
+        }
         
         public void Dispose()
         {

--- a/GameServer/Migrations/20260710070018_AddRemoveProfileAvatarsPermission.Designer.cs
+++ b/GameServer/Migrations/20260710070018_AddRemoveProfileAvatarsPermission.Designer.cs
@@ -4,6 +4,7 @@ using GameServer.Utils;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GameServer.Migrations
 {
     [DbContext(typeof(Database))]
-    partial class DatabaseModelSnapshot : ModelSnapshot
+    [Migration("20260710070018_AddRemoveProfileAvatarsPermission")]
+    partial class AddRemoveProfileAvatarsPermission
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -340,10 +343,10 @@ namespace GameServer.Migrations
                     b.Property<bool>("ManageBannedConsoleIDs")
                         .HasColumnType("tinyint(1)");
 
-                    b.Property<bool>("ManageHotlap")
+                    b.Property<bool>("ManageBannedIPs")
                         .HasColumnType("tinyint(1)");
 
-                    b.Property<bool>("ManageBannedIPs")
+                    b.Property<bool>("ManageHotlap")
                         .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("ManageModerators")

--- a/GameServer/Migrations/20260710070018_AddRemoveProfileAvatarsPermission.cs
+++ b/GameServer/Migrations/20260710070018_AddRemoveProfileAvatarsPermission.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GameServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRemoveProfileAvatarsPermission : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RemoveProfileAvatars",
+                table: "Moderators",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.Sql("UPDATE Moderators SET RemoveProfileAvatars = RemoveProfileComments;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RemoveProfileAvatars",
+                table: "Moderators");
+        }
+    }
+}

--- a/GameServer/Models/IUGCStorage.cs
+++ b/GameServer/Models/IUGCStorage.cs
@@ -28,5 +28,6 @@ namespace GameServer.Models
         public long CalculateSize(int id, string file);
         public void RemovePlayerCreation(int id);
         public void RemoveGhostCarData(GameType gameType, Platform platform, int trackId, int playerId);
+        public void RemoveProfileAvatars(int id, bool isMNR = false);
     }
 }

--- a/GameServer/Models/Moderation/ModeratorPermissions.cs
+++ b/GameServer/Models/Moderation/ModeratorPermissions.cs
@@ -14,6 +14,7 @@
         public bool RemovePlayerCreations { get; set; }
         public bool RemovePlayerCreationComments { get; set; }
         public bool RemoveProfileComments { get; set; }
+        public bool RemoveProfileAvatars { get; set; }
         public bool ManageAnnouncements { get; set; }
         public bool ManageHotlap { get; set; }
         public bool RemoveScores { get; set; }

--- a/GameServer/Models/PlayerData/Moderator.cs
+++ b/GameServer/Models/PlayerData/Moderator.cs
@@ -23,6 +23,7 @@ namespace GameServer.Models.PlayerData
         public bool RemovePlayerCreations { get; set; }
         public bool RemovePlayerCreationComments { get; set; }
         public bool RemoveProfileComments { get; set; }
+        public bool RemoveProfileAvatars { get; set; }
         public bool ManageAnnouncements { get; set; }
         public bool ManageHotlap { get; set; }
         public bool RemoveScores { get; set; }
@@ -58,7 +59,8 @@ namespace GameServer.Models.PlayerData
                    && (!permissions.ResetUserStats || ResetUserStats)
                    && (!permissions.RemoveUsers || RemoveUsers)
                    && (!permissions.ManageSystemEvents || ManageSystemEvents)
-                   && (!permissions.ManageUserSessions || ManageUserSessions);
+                   && (!permissions.ManageUserSessions || ManageUserSessions)
+                   && (!permissions.RemoveProfileAvatars || RemoveProfileAvatars);
         }
 
         public ModeratorPermissions GetPermissions()
@@ -87,7 +89,8 @@ namespace GameServer.Models.PlayerData
                 RemoveUsers = RemoveUsers,
                 ManageUserSessions = ManageUserSessions,
                 ManageBannedIPs = ManageBannedIPs,
-                ManageBannedConsoleIDs = ManageBannedConsoleIDs
+                ManageBannedConsoleIDs = ManageBannedConsoleIDs,
+                RemoveProfileAvatars = RemoveProfileAvatars
             };
         }
         


### PR DESCRIPTION
- added RemoveProfileAvatars api endpoint and permission as well
- added console id ban endpoints using player session lookup, cache last connection in memory for session based banning (only console id because false ip bans can happen)
- added that leaked mnr build title id
- I didn't know psp used skill levels so I added it to the players api endpoint